### PR TITLE
Add all Forgotten Runes collection metadata to Rinkeby

### DIFF
--- a/pages/api/v2/rinkeby/0x251b5f14a825c537ff788604ea1b58e49b70726f.js
+++ b/pages/api/v2/rinkeby/0x251b5f14a825c537ff788604ea1b58e49b70726f.js
@@ -1,0 +1,76 @@
+////////////////////
+// Forgotten Souls
+////////////////////
+
+const axios = require('axios')
+let rank = {
+    "Head":9,
+    "Body":8,
+    "Familiar":7,
+    "Prop":6,
+    "Rune":5,
+    "Background":4,
+    "Affinity":3,
+    "Undesirable":2
+}
+ 
+const api = async (req, res) => {
+  if(req.query.token_ids) {
+    let token_ids = Array.isArray(req.query.token_ids) ? req.query.token_ids : [req.query.token_ids];
+    let data = await getBatch(token_ids) 
+    res.status(200).json(data);
+  } else {
+      res.status(200).json({"error": "Missing token_ids param"});
+  }
+};
+
+async function getBatch(token_ids) {
+  let promises = token_ids.map(token_id => getToken(token_id));
+  return Promise.all(promises).then((data) => {
+      return data
+  });
+}
+
+async function getToken(id) {
+  let url = `https://portal.forgottenrunes.com/api/souls/data/${id}`
+  return axios.get(url).then((response) => {
+    if(response.data) {
+      let attributes = response.data.attributes.reduce((result,trait) => {
+            let trait_type = trait.trait_type.charAt(0).toUpperCase() + trait.trait_type.slice(1)
+            result.push({
+              "key": trait_type,
+              "rank": rank[trait_type] ? rank[trait_type] : -1,
+              "value": trait.value,
+              "kind": isNaN(trait.value) ? "string" : "number"
+            })
+            return result
+      },[])
+      let meta = {
+        "token_id":id,
+        "name": response.data.name,
+        "description": null, 
+        "image": response.data.image,
+        "community": "forgottenrunes",
+        "collection": {
+            "id": "forgottensouls",
+            "setId":`contract:0x251b5f14a825c537ff788604ea1b58e49b70726f`,
+            "name": "Forgotten Souls",
+            "description": "The Forgotten Souls are the transmuted Souls of the Forgotten Runes Wizard's Cult. Each is created by burning both a Wizard and a Sacred Flame. No more than 1112 Forgotten Souls will ever exist.",
+            "image": "https://lh3.googleusercontent.com/YmqENqCWQEmEez-F6bj3b0rLa6nTyUEuB1OXdmxX5bGIg69LLKIucfkTZeOjkMMv0_eSPsCgr_vUqIPpXldSdZm5ZZSVI508ld32YWI",
+            "royaltyBps": "666",
+            "royaltyRecipient": "0xd584fe736e5aad97c437c579e884d15b17a54a51",
+            "community": "forgottenrunes",
+        },
+        "attributes":attributes
+      }
+      return meta
+    } else {
+      return {"token_id":id,"skip":false}
+    }
+  }).catch((error)=>{
+    console.log(error)
+    return {"token_id":id,"skip":false}
+  })
+};
+
+export default api;

--- a/pages/api/v2/rinkeby/0xf55b615b479482440135ebf1b907fd4c37ed9420.js
+++ b/pages/api/v2/rinkeby/0xf55b615b479482440135ebf1b907fd4c37ed9420.js
@@ -1,20 +1,9 @@
 ////////////////////
-// Forgotten Runes Wizards Cult
+// Forgotten Runes Ponies
 ////////////////////
+
 const axios = require('axios')
-let rank = {
-    "Head":11,
-    "Body":10,
-    "Familiar":9,
-    "Prop":8,
-    "Rune":7,
-    "Background":6,
-    "Affinity":5,
-    "% Traits in Affinity":4,
-    "# Traits in Affinity":3,
-    "# Traits":2
-}
- 
+
 const api = async (req, res) => {
   if(req.query.token_ids) {
     let token_ids = Array.isArray(req.query.token_ids) ? req.query.token_ids : [req.query.token_ids];
@@ -33,41 +22,31 @@ async function getBatch(token_ids) {
 }
 
 async function getToken(id) {
-  let url = `https://bafybeifd5ctqsiszoveqqtran7tvyg4xpjxu67nthf5n6ugdazeox5n5fa.ipfs.infura-ipfs.io/${id}`
+  let url = `https://portal.forgottenrunes.com/api/shadowfax/data/${id}`
   return axios.get(url).then((response) => {
     if(response.data) {
       let attributes = response.data.attributes.reduce((result,trait) => {
-          if(trait.trait_type!=="Serial") {
             let trait_type = trait.trait_type.charAt(0).toUpperCase() + trait.trait_type.slice(1)
-            let kind = "string"
-            if(trait_type=="% Traits in Affinity") {
-                trait.value = trait.value.slice(0,-1)
-            }
-            if(trait_type.indexOf("Traits")!==-1) {
-                kind = "number"
-            }
             result.push({
               "key": trait_type,
-              "rank": rank[trait_type],
               "value": trait.value,
-              kind
+              "kind": isNaN(trait.value) ? "string" : "number"
             })
-          }
-        return result
+            return result
       },[])
       let meta = {
         "token_id": id,
         "name": response.data.name,
         "description": null, 
-        "image": `https://bafybeigjl2wwcakyvqd4s6odmmyy3lqxiyffv3wk4su5p5bincksxgga2a.ipfs.infura-ipfs.io/${id}.png`,
+        "image": response.data.image,
         "community": "forgottenrunes",
         "collection": {
-            "id": "forgottenruneswizardscult",
-            "setId":`contract:0x521f9c7505005cfa19a8e5786a9c3c9c9f5e6f42`,
-            "name": "Forgotten Runes Wizards Cult",
-            "description": "The Forgotten Runes Wizard's Cult is a collaborative legendarium. 10,000 unique Wizard NFTs, fully encoded on-chain.",
-            "image": "https://lh3.googleusercontent.com/rfEd3YcRfS8Hk8YcZjD20Vrqu8XTazvnzklVN9pUcROrwhoLO8RbP0yiBQuemgGPpWMgEDGU7qO164x42GRn60Xv6aeFbdZkttzBjx8",
-            "royaltyBps": "250",
+            "id": "forgottenrunesponies",
+            "setId":`contract:0xf55b615b479482440135ebf1b907fd4c37ed9420`,
+            "name": "Forgotten Runes Ponies",
+            "description": "On a crisp December 24th, 2021 snow fell on the secret tower, a rumble in the distance. Then a whinny. From the Elysian Fields, a herd of 567 ponies appeared in the Forgotten Runiverse. The minting was free (+gas) for anyone who received a merch box or held a Wizard (or Soul) that had Lore (details below).",
+            "image": "https://lh3.googleusercontent.com/3TPhA6JRPww4xSe6EwDTS8rj1VyQVLOOFH__C_ckJSd63zBx4WJx3U1deEtCVgaWJBmC5aTdDGneFAa4y7SpM86pJFBHOD4rdNG8",
+            "royaltyBps": "444",
             "royaltyRecipient": "0xd584fe736e5aad97c437c579e884d15b17a54a51",
             "community": "forgottenrunes",
         },


### PR DESCRIPTION
For testing purposes, adding metadata for all Forgotten Runes collections on Rinkeby, and updating to match 1:1 with mainnet