### PR TITLE
(fix) titleSlug -> id

### DIFF
--- a/src/custom/soundxyz/index.js
+++ b/src/custom/soundxyz/index.js
@@ -62,8 +62,8 @@ export const fetchCollection = async (_chainId, { contract, tokenId }) => {
     const [fundingAddress, royaltyBPS] = await nftContract.royaltyInfo(tokenId, BPS_100);
 
     return {
-        id: `${contract}:${nft.release.titleSlug}`,
-        slug: slugify(nft.release.titleSlug, { lower: true }),
+        id: `${contract}:${nft.release.id}`,
+        slug: slugify(nft.release.id, { lower: true }),
         name: nft.release.title,
         community: "sound.xyz",
         metadata: {
@@ -96,7 +96,7 @@ export const fetchToken = async (_chainId, { contract, tokenId }) => {
     );
 
     if (!_.isEmpty(newMetadata)) {
-      newMetadata[0].collection = `${contract}:${nft.release.titleSlug}`;
+      newMetadata[0].collection = `${contract}:${nft.release.id}`;
       return newMetadata[0];
     }
   } catch (error) {


### PR DESCRIPTION
use the `id` of the release instead of the titleSlug since it's more likely to be unique and unchanging.

example id: 88c6418c-75c5-442d-a581-cb155ccdc19e