### PR TITLE
feat: add soundxyz artist name

### DIFF
--- a/src/custom/soundxyz/index.js
+++ b/src/custom/soundxyz/index.js
@@ -74,7 +74,7 @@ export const fetchCollection = async (_chainId, { contract, tokenId }) => {
     return {
         id: `${contract}:soundxyz-${nft.release.id}`,
         slug: slugify(nft.release.titleSlug, { lower: true }),
-        name: nft.release.title,
+        name: `${nft.release.artist.name} – ${nft.release.title}`,
         community: "sound.xyz",
         metadata: {
           imageUrl: nft.release.coverImage.url,


### PR DESCRIPTION
Adding artist names to soundxyz metadata allows the frontend to access both properties and allows searching by artist name and release title for free.

OLD collection name: release (song) name
NEW collection name: Artist Name – Song name

To avoid inevitable weirdness (eg hyphenated artist names or song titles), I've made the divider an em-dash instead of an en-dash (– vs -)