### PR TITLE
fix: soundxyz image field

### DIFF
--- a/src/extend/soundxyz/index.js
+++ b/src/extend/soundxyz/index.js
@@ -6,7 +6,7 @@ export const extend = async (_chainId, metadata) => {
     metadata.name = nft.release.title;
     metadata.collection = `${metadata.contract}:soundxyz-${nft.release.id}`;
     metadata.description = nft.release.behindTheMusic;
-    metadata.imageUrl = nft.release.coverImage.imageUrl;
+    metadata.imageUrl = nft.release.coverImage.url;
     return { ...metadata };
   } catch (error) {
     throw error


### PR DESCRIPTION
It's accessing `coverImage.imageUrl` but the field is actually `coverImage.url`.

This is resulting in new collections not getting images.