### PR TITLE
fix golden egg images on sound

### DIFF
--- a/src/custom/soundxyz/index.js
+++ b/src/custom/soundxyz/index.js
@@ -34,6 +34,7 @@ export const getContractSlug = async (chainId, contract, tokenId) => {
                 }
                 release {
                     id
+                    isGoldenEgg
                     title
                     titleSlug
                     behindTheMusic
@@ -52,8 +53,10 @@ export const getContractSlug = async (chainId, contract, tokenId) => {
                     coverImage {
                         url
                     }
-                    goldenEggImage {
+                    eggGame {
+                      goldenEggImage {
                         url
+                      }
                     }
                     track {
                         id

--- a/src/parsers/soundxyz.js
+++ b/src/parsers/soundxyz.js
@@ -6,7 +6,7 @@ export const parse = (contract, tokenId, collection, nft) => {
     name: nft.release.title,
     flagged: false,
     description: nft.release.behindTheMusic,
-    imageUrl: nft.release.coverImage.url,
+    imageUrl: nft.isGoldenEgg ? nft.eggGame.goldenEggImage.url : nft.release.coverImage.url,
     mediaUrl: nft.release.track.revealedAudio.url,
     attributes: (nft.openSeaMetadataAttributes || []).map((trait) => ({
       key: trait.traitType || "property",


### PR DESCRIPTION
Switching images to the sound API introduced a bug in image fetching -- golden egg images don't use the `release.coverImage`, they use a special image instead.

This PR fixes that issue by fetching whether this NFT is the golden egg or not. It also migrates the goldenEggImage to a different field, since prev one was technically deprecated (though this was not impacting things afaik)