### PR TITLE
add fetchCollection for onchain provider

### DIFF
--- a/pages/api/v4/[network]/metadata/collection.js
+++ b/pages/api/v4/[network]/metadata/collection.js
@@ -8,6 +8,7 @@ import * as rarible from "../../../../../src/fetchers/rarible";
 import * as simplehash from "../../../../../src/fetchers/simplehash";
 import * as centerdev from "../../../../../src/fetchers/centerdev";
 import * as soundxyz from "../../../../../src/fetchers/soundxyz";
+import * as onchain from "../../../../../src/fetchers/onchain";
 
 const api = async (req, res) => {
   try {
@@ -45,7 +46,9 @@ const api = async (req, res) => {
 
     // Validate indexing method and set up provider
     const method = req.query.method;
-    if (!["opensea", "rarible", "simplehash", "centerdev", "soundxyz"].includes(method)) {
+    if (
+      !["opensea", "rarible", "simplehash", "centerdev", "soundxyz", "onchain"].includes(method)
+    ) {
       throw new Error("Unknown method");
     }
 
@@ -58,6 +61,8 @@ const api = async (req, res) => {
       provider = centerdev;
     } else if (method === "soundxyz") {
       provider = soundxyz;
+    } else if (method === "onchain") {
+      provider = onchain;
     }
 
     const token = req.query.token?.toLowerCase();

--- a/src/fetchers/onchain.js
+++ b/src/fetchers/onchain.js
@@ -1,6 +1,7 @@
 import { defaultAbiCoder, solidityPack } from "ethers/lib/utils";
 import { ethers } from "ethers";
 import fetch from "node-fetch";
+import slugify from "slugify";
 import { parse } from "../parsers/onchain";
 import { RequestWasThrottledError } from "./errors";
 
@@ -270,6 +271,20 @@ export const fetchTokens = async (chainId, tokens) => {
   });
 };
 
-export const getCollectionMetadata = async (contractAddress, chainId) => {};
-
 export const fetchContractTokens = async (chainId, contract, from, to) => {};
+
+export const fetchCollection = async (chainId, { contract, tokenId }) => {
+  const [tokenMetadata] = await fetchTokens(chainId, { contract, tokenId });
+  const collectionName = tokenMetadata.name ? tokenMetadata.name.split(" ")[0].trim() : "";
+  return {
+    id: contract,
+    slug: slugify(collectionName, { lower: true }),
+    name: collectionName,
+    metadata: {
+      description: tokenMetadata.description,
+      imageUrl: tokenMetadata.imageUrl,
+    },
+    contract,
+    tokenSetId: `contract:${contract}`,
+  };
+};


### PR DESCRIPTION
I found that the current `onchain` provider doesn't contains a `fetchCollection` method, this pr added it.

Collection metadata was not included on chain, so I'm using a token's metadata as the collection's metadata


## Test env setup:

.env: 

```
RPC_URL_534353=https://alpha-rpc.scroll.io/l2
```

blockscout: https://blockscout.scroll.io/

## Test 1: 

token=0x59ef5d23edea409fbd03761a57d7078e475f8419:92876

```bash
curl 'http://localhost:3000/api/v4/scroll-alpha/metadata/collection?method=onchain&token=0x59ef5d23edea409fbd03761a57d7078e475f8419:92876'
```
```json
{"collection":{"id":"0x59ef5d23edea409fbd03761a57d7078e475f8419","slug":"","name":"","metadata":{"description":null,"imageUrl":null},"contract":"0x59ef5d23edea409fbd03761a57d7078e475f8419","tokenSetId":"contract:0x59ef5d23edea409fbd03761a57d7078e475f8419"}}
```

## Test 2:

This kind of contract contains a lot of metadata

token=0x09ffd4248f735965795bb36df9754ec58e872caa:16522

```bash
curl 'http://localhost:3000/api/v4/scroll-alpha/metadata/collection?method=onchain&token=0x09ffd4248f735965795bb36df9754ec58e872caa:16522'
```

```json
{"collection":{"id":"0x09ffd4248f735965795bb36df9754ec58e872caa","slug":"punk","name":"Punk","metadata":{"description":"The Scroll Punks is a collection of 50,000 unique NFTs with varying rarity and style. The first algorithmically generated digital collection of diverse Punk NFTs chilling on the Scroll blockchain. Each character is impeccably designed, thoughtfully picked and super funky!","imageUrl":"https://ipfs.io/ipfs/QmWLfvSmJUzvxHesVG3fJMcmrKMVbXkKcoWZf7GKuxhuWK/6522.png"},"contract":"0x09ffd4248f735965795bb36df9754ec58e872caa","tokenSetId":"contract:0x09ffd4248f735965795bb36df9754ec58e872caa"}}
```

## Test 3:

token=0xbd1A5920303F45d628630E88aFbAF012bA078F37:545549

<img width="611" alt="image" src="https://user-images.githubusercontent.com/4054836/234456943-4d3c3915-814d-4f91-a204-1f9e15c2b5f5.png">

metadata of this kind of token won't be parsed

```bash
curl 'http://localhost:3000/api/v4/scroll-alpha/metadata/collection?method=onchain&token=0xbd1A5920303F45d628630E88aFbAF012bA078F37:545549'
```

```json
{"collection":{"id":"0xbd1a5920303f45d628630e88afbaf012ba078f37","slug":"","name":"","metadata":{"description":null,"imageUrl":null},"contract":"0xbd1a5920303f45d628630e88afbaf012ba078f37","tokenSetId":"contract:0xbd1a5920303f45d628630e88afbaf012ba078f37"}}
```