### PR TITLE
extend one feral file collection

### DIFF
--- a/src/extend/feral-file/index.js
+++ b/src/extend/feral-file/index.js
@@ -1,0 +1,39 @@
+const collectionsTokenIdRange = [
+  [
+    "Winslow Homer's Croquet Challenge by Mitchell F. Chan",
+    "25811853076941608055270457512038717433705462539422789705262203111341130500760",
+    "25811853076941608055270457512038717433705462539422789705262203111341130501225",
+  ],
+];
+
+const getCollectionTokenIdRange = (contract, tokenId) => {
+  return collectionsTokenIdRange.find(
+    (collectionInfo) =>
+      collectionInfo[1] <= tokenId.toString() && tokenId.toString() <= collectionInfo[2]
+  );
+};
+
+export const extendCollection = async (chainId, metadata, tokenId) => {
+  const collection = getCollectionTokenIdRange(metadata.contract, metadata.tokenId);
+
+  if (collection) {
+    const [collectionName, startTokenId, endTokenId] = collection;
+    metadata.name = collectionName;
+    metadata.id = `${metadata.contract.toLowerCase()}:${startTokenId}:${endTokenId}`;
+    metadata.tokenIdRange = [start, end];
+    metadata.tokenSetId = `range:${contract.toLowerCase()}:${startTokenId}:${endTokenId}`;
+  }
+  return metadata;
+};
+
+export const extend = async (_chainId, metadata) => {
+  const collection = getCollectionTokenIdRange(metadata.contract, metadata.tokenId);
+
+  if (collection) {
+    const [collectionName, startTokenId, endTokenId] = collection;
+    metadata.name = collectionName;
+    metadata.collection = `${metadata.contract.toLowerCase()}:${startTokenId}:${endTokenId}`;
+  }
+
+  return metadata;
+};

--- a/src/extend/index.js
+++ b/src/extend/index.js
@@ -136,6 +136,7 @@ extend["1,0x82c7a8f707110f5fbb16184a5933e9f78a34c6ab"] = emblemVault;
 
 // Feral File
 extend["1,0x2a86c5466f088caebf94e071a77669bae371cd87"] = feralFile;
+
 // BrainDrops
 extend["1,0xdfde78d2baec499fe18f2be74b6c287eed9511d7"] = brainDrops;
 

--- a/src/extend/index.js
+++ b/src/extend/index.js
@@ -11,6 +11,7 @@ import * as soundxyz from "../custom/soundxyz";
 import * as soundxyzExtend from "./soundxyz";
 import * as bayc from "./bayc";
 import * as asyncBlueprints from "./async-blueprints";
+import * as feralFile from "./feral-file";
 import * as tfoust from "./tfoust";
 import * as sharedContracts from "./shared-contracts";
 import * as cyberkongz from "./cyberkongz";
@@ -79,6 +80,9 @@ extendCollection["1,0xabefbc9fd2f806065b4f3c237d4b59d9a97bcac7"] = sharedContrac
 // Emblem Vault
 extendCollection["1,0x82c7a8f707110f5fbb16184a5933e9f78a34c6ab"] = emblemVault;
 
+// Feral File
+extendCollection["1,0x2a86c5466f088caebf94e071a77669bae371cd87"] = feralFile;
+
 // BrainDrops
 extendCollection["1,0xdfde78d2baec499fe18f2be74b6c287eed9511d7"] = brainDrops;
 
@@ -130,6 +134,8 @@ tfoust.CollectiblesCollections.forEach((c) => (extend[`137,${c}`] = tfoust));
 // Emblem Vault
 extend["1,0x82c7a8f707110f5fbb16184a5933e9f78a34c6ab"] = emblemVault;
 
+// Feral File
+extend["1,0x2a86c5466f088caebf94e071a77669bae371cd87"] = feralFile;
 // BrainDrops
 extend["1,0xdfde78d2baec499fe18f2be74b6c287eed9511d7"] = brainDrops;
 


### PR DESCRIPTION
Break a token range out into its own collection (artblocks style).

I couldn't tell if `extendCollection` in `extend` was the right thing to do vs something in `custom` with a `fetchCollection`.

The expected behavior is that this breaks this one collection (a contract) into two -- one that's a token range, and one for everything else in the contract outside of the tokenrange.